### PR TITLE
Phase III Build 19:

### DIFF
--- a/Server/WcfService/BusinessLayer/Loyalty/CustomLoyBLL.cs
+++ b/Server/WcfService/BusinessLayer/Loyalty/CustomLoyBLL.cs
@@ -123,8 +123,13 @@ namespace LSOmni.BLL.Loyalty
                 throw new LSOmniException(StatusCode.EmailInvalid, "Validation of email failed");
 
             //check if user exist before calling NAV
-            if (config.SettingsBoolGetByKey(ConfigKey.Allow_Dublicate_Email) == false && BOLoyConnection.ContactGet(ContactSearchType.Email, contact.Email, stat) != null)
-                throw new LSOmniServiceException(StatusCode.EmailExists, "Email already exists: " + contact.UserName);
+            if (config.SettingsBoolGetByKey(ConfigKey.Allow_Dublicate_Email) == false)
+            {
+                MemberContact contactFromDB = BOLoyConnection.ContactGet(ContactSearchType.Email, contact.Email, stat);
+                if (contactFromDB != null)
+                    if (contactFromDB.Cards.Find(x => x.Id == contact.UserName) == null)
+                        throw new LSOmniServiceException(StatusCode.EmailExists, "Email already exists: " + contact.UserName);
+            }
 
             if (string.IsNullOrEmpty(contact.AuthenticationId) == false)
             {

--- a/Server/WcfService/DataAccess/BOConnection.PreCommon/JMapping/ContactJMapping.cs
+++ b/Server/WcfService/DataAccess/BOConnection.PreCommon/JMapping/ContactJMapping.cs
@@ -46,8 +46,11 @@ namespace LSOmni.DataAccess.BOConnection.PreCommon.JMapping
                 }
                 cont.UserName = LoadOneValue(result.GetDataSet(99009049), "Card No.", cont.Cards.FirstOrDefault().Id, "Login ID");
                 cont.Account = accounts.Find(x => x.Id == cont.Account.Id);
-                cont.Account.Scheme = schemes.Find(x => x.Id == cont.Account.SchemeCode);
-                cont.Account.Scheme.Club = clubs.Find(x => x.Id == cont.Account.Scheme.ClubCode);
+                if (!string.IsNullOrEmpty(cont.Account.SchemeCode)) //anmo
+                {
+                    cont.Account.Scheme = schemes.Find(x => x.Id == cont.Account.SchemeCode);
+                    cont.Account.Scheme.Club = clubs.Find(x => x.Id == cont.Account.Scheme.ClubCode);
+                }
                 cont.Profiles = profiles.FindAll(x => x.AccountNo == cont.Account.Id && x.ContactNo == cont.Id);
 
                 string key = "LSC Member Account: " + cont.Account.Id;

--- a/Server/WcfService/DataAccess/BOConnection.PreCommon/PreCommonLoyalty.cs
+++ b/Server/WcfService/DataAccess/BOConnection.PreCommon/PreCommonLoyalty.cs
@@ -853,8 +853,12 @@ namespace LSOmni.DataAccess.BOConnection.PreCommon
                 string ret = SendToOData("GetMemberContactInfo_GetMemberContactInfo", data);
                 ContactJMapping cmap = new ContactJMapping(config.IsJson);
                 List<MemberContact> list = cmap.GetMemberContact(ret);
+                contact = list.FirstOrDefault(); //anmo
+                Card myCard = contact.Cards.Find(x => x.Id == card); //anmo
+                if (myCard != null) //anmo
+                    contact.UserName = myCard.LoginId; //anmo
                 logger.StatisticEndSub(ref stat, index);
-                return list.FirstOrDefault();
+                return contact; //anmo
             }
 
             LSCentral.RootGetMemberContact rootContact = new LSCentral.RootGetMemberContact();


### PR DESCRIPTION
fix: create login for existing card was giving duplicate e-mail error when same contact email was used
fix: username missing error upon when user had two cards and age verification got status pending
fix: null reference error when member account schema was blank and age verifcation got status pending